### PR TITLE
Update plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "Env",
     "Description": "Control Environment Variables from Flow Launcher",
     "Author": "lurebat",
-    "Version": "1.0.0",
+    "Version": "1.1.0",
     "Language": "csharp",
     "Website": "https://github.com/lurebat/Flow.Launcher.Plugin.Env",
     "IcoPath": "icon.png",


### PR DESCRIPTION
Plugin JSON didn't reflect new version number, causing flowlauncher to thing the plugin needed updating to 1.1 despite already being on that version.